### PR TITLE
Feature: rebar3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ebin/*.app
 ebin/*.beam
 *.beam
 *.d
+_build

--- a/src/eministat.app.src
+++ b/src/eministat.app.src
@@ -1,0 +1,15 @@
+{application, 'eministat',
+ [{description, "Basic statistics for comparing datasets from benchmarks"},
+  {vsn, "0.10.1"},
+  {registered, []},
+  {applications,
+   [kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+
+  {maintainers, ["Jesper Louis Andersen"]},
+  {licenses, []},
+  {links, []}
+ ]}.


### PR DESCRIPTION
Adds a .app.src file for eministat so that rebar3 will correctly detect
and build the project. The gitignore file is updated to include rebar3's
`_build` directory.

The project can now be built with:

```
    $ rebar3 compile
```

And the project can be immediately used with:

```
    $ rebar3 shell
```
