### PR TITLE
Don't assume that the benchmark won't flush the message queue

### DIFF
--- a/src/eministat.erl
+++ b/src/eministat.erl
@@ -107,17 +107,18 @@ s_run(F, G, K) ->
     s_bench(F, G, K).
 
 s_warmup(F) ->
-    erlang:send_after(3000, self(), warmup_over),
-    s_warmup_loop(F).
-    
-s_warmup_loop(F) ->
-    receive
-        warmup_over -> ok
-    after 0 ->
-        F(),
-        F(),
-        F(),
-        s_warmup_loop(F)
+    s_warmup_loop(F, erlang:timestamp()).
+
+s_warmup_loop(F, StartTs) ->
+    Elapsed = timer:now_diff(erlang:timestamp(), StartTs),
+    if
+	Elapsed > 3000000 ->
+	    ok;
+	true ->
+	    F(),
+	    F(),
+	    F(),
+	    s_warmup_loop(F, StartTs)
     end.
 
 s_bench(_F, _G, 0) -> [];


### PR DESCRIPTION
eministat:s_warmup/1 schedules the sending of a 'warmup_over' message
to self() to stop warmup after 3 seconds. If the benchmarked function
flushes the message queue, the message can be lost and warmup go on
indefinitely.

This patch changes s_warmup/1 to not rely on message sending, instead
s_warmup/1 remembers when it started and terminates the warmup loop
when 3s have elapsed.